### PR TITLE
Show las comment's author with verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gissuel
 
 ## Usage
 
-- Run `gissuel get --label [label] --repo [repo-name] --body`
+- Run `gissuel get --label [label] --repo [repo-name] --verbose`
 
     For example, I added lines similar to the following to my `.zshrc` file
 
@@ -22,7 +22,7 @@ Gissuel
 - Options are optional
   - `--repo` (`--label`) - When not specified, Gissuel will look for any issue 
   that is assigned to token owner. Otherwise, it will only look for specified repo (label).
-  - `--body`  - when Gissuel is called with this option, it will show text for
+  - `--verbose`  - when Gissuel is called with this option, it will show text for
   each found issue
   - `--index` - combined with above mentioned options, it will print only an issue
   under the specified ordinal number
@@ -44,5 +44,5 @@ gissuel get --repo semaphoreci/semaphore --label planned
 ```
 Finally, from the last list, I'd like to see description of second issue
 ```
-gissuel get --repo semaphoreci/semaphore --label planned --index 2 --body
+gissuel get --repo semaphoreci/semaphore --label planned --index 2 --verbose
 ```

--- a/lib/gissuel/cli.rb
+++ b/lib/gissuel/cli.rb
@@ -1,7 +1,7 @@
 module Gissuel
 
   class CLI < Thor
-    attr_reader :label, :repo, :body, :index
+    attr_reader :label, :repo, :verbose, :index
 
     desc "get", "will print out list of issues assigned to you"
 
@@ -17,15 +17,15 @@ module Gissuel
 
     option :label
     option :repo
-    option :body, :lazy_default => true, :default => false, :type => :boolean
+    option :verbose, :lazy_default => true, :default => false, :type => :boolean
     option :index, :default => 0, :type => :numeric
     def get
       @label = options[:label]
       @repo  = options[:repo]
-      @body  = options[:body]
+      @verbose  = options[:verbose]
       @index = options[:index]
 
-      Gissuel::Issues.new(label, repo, body, index).publish
+      Gissuel::Issues.new(label, repo, verbose, index).publish
     end
 
     desc "version", "Prints the haskii version info"

--- a/lib/gissuel/issues.rb
+++ b/lib/gissuel/issues.rb
@@ -3,12 +3,12 @@ module Gissuel
 
     TOKEN = ENV["GITHUB_TOKEN"]
     
-    def initialize(label, repo, body, index)
-      @label = label
-      @repo  = repo
-      @state = "open"
-      @body  = body
-      @index = index
+    def initialize(label, repo, verbose, index)
+      @verbose  = verbose
+      @label    = label
+      @repo     = repo
+      @state    = "open"
+      @index    = index
     end
 
     def publish
@@ -47,10 +47,11 @@ module Gissuel
         if @index.zero? then
           Gissuel::Log.new("👋  there is one issue on your 🍽️.").red
           Gissuel::Log.new("☕  here is quick look at it:\n").grey
+          report_issue(issues.first, @index + 1)
         else 
           Gissuel::Log.new("☕  here is quick look at the issue:\n").grey
-        end
           report_issue(issues.first, @index)
+        end
       else
         Gissuel::Log.new("👋  there are #{issues.count} issues on your 🍽️.").red
         Gissuel::Log.new("☕  here is quick look at these:\n").grey
@@ -64,8 +65,25 @@ module Gissuel
     def report_issue(issue, index)
       Gissuel::Log.new("[#{index}]: #{issue.title}").yellow
       Gissuel::Log.new("URL: #{issue.html_url}").blue
-      Gissuel::Log.new("BODY: #{issue.body}").grey if @body
-      Gissuel::Log.new("No of comments: #{issue.comments} | Updated at: #{issue.updated_at}\n").green
+      Gissuel::Log.new("DESCRIPTION: #{issue.body}").grey if @verbose
+      Gissuel::Log.new(comments_report(issue)).green
+    end
+
+    def comments_report(issue)
+      general_info = "No of comments: #{issue.comments} | Updated at: #{issue.updated_at}"
+
+     # comment_autor_requested? ? [general, comment_author(issue)].join(" | ") : general
+     issue.comments.nonzero? && @verbose ? [general_info, last_comment_author(issue)].join(" | ") : general_info
+    end
+
+    def last_comment_author(issue)
+      repo = issue.repository_url
+                        .split("/")
+                        .last(2)
+                        .join("/")
+
+      client.issue_comments(repo, issue.number).last
+            .user.login
     end
 
   end

--- a/lib/gissuel/version.rb
+++ b/lib/gissuel/version.rb
@@ -1,3 +1,3 @@
 module Gissuel
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This PR replaces `--body` with `--verbose`. Also, when `--verbose` is passed, `gissuel` will display author of last comment per issue.

Closes #3 